### PR TITLE
[CORS] Fix configuration CORS invalide

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -17,7 +17,6 @@ app = FastAPI(
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],
-    allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
 )


### PR DESCRIPTION
Supprime allow_credentials=True incompatible avec allow_origins=["*"] selon la spec CORS — les navigateurs bloquaient toutes les requêtes. Les Bearer tokens JWT ne nécessitent pas le mode credentials.